### PR TITLE
escape backward paren in link to boisso

### DIFF
--- a/notebooks/05_simulating_random_population.ipynb
+++ b/notebooks/05_simulating_random_population.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b8d59e19-153c-4ff5-ad3c-f7bf05c62adc",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-23T21:53:15.406366Z",
@@ -18,7 +17,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4073bd1d-c70a-4e67-8025-a90a7f472487",
    "metadata": {},
    "source": [
     "For conducting single-value inference, the `segregation` package offer several techniques for generating random population distributions that respect the characteristics of an input dataset. This notebook walks through the assumptions and outputs of each approach"
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6f81d49-560c-4521-bb19-53609df1b96c",
    "metadata": {},
    "source": [
     "## TL:DR:\n",
@@ -39,7 +36,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f41d8409-1788-47b3-b286-a709ae17a771",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:09.810770Z",
@@ -77,7 +73,6 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "15414228-092b-4a54-8270-5a0bc0d42370",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:15.734736Z",
@@ -99,7 +94,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "82bf055e-6255-46d7-a680-3c6a43d597ef",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:15.757678Z",
@@ -118,7 +112,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d11dcb13-9643-4f40-80bc-1e6cb5a1d076",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.073679Z",
@@ -136,7 +129,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "2e04d955-3da7-4430-a690-b2d0d1ed9170",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.304680Z",
@@ -165,7 +157,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "a76d1f08-d882-4cf7-a0eb-b36314467bfd",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.313403Z",
@@ -194,7 +185,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a63ea618-6427-43d4-b9f5-147ba9a74776",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.319802Z",
@@ -223,7 +213,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "b63369a0-be17-4b23-b2b2-59c1774a9361",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.327582Z",
@@ -241,7 +230,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "3ed1d2dc-71c3-49ba-8fbf-f82539e9452f",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.382271Z",
@@ -258,7 +246,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ada01b11-381f-4553-82b9-62987459487f",
    "metadata": {},
    "source": [
     "## Evenness"
@@ -266,7 +253,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c73b51b9-d016-43c9-8e07-58fb9cde85b7",
    "metadata": {},
    "source": [
     "Evenness takes draws from the population of each unit, with the probability of choosing group X equal to its regional share (locations drawing from distributions of population groups)"
@@ -275,7 +261,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "69e0e492-0324-4753-adda-72f4e16d0f38",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.405344Z",
@@ -305,7 +290,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "09af8497-f1bb-4f24-bdbb-d7706a3c4571",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.411300Z",
@@ -385,7 +369,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8aaa03d5-b599-42ce-bdd5-2d6885c3601b",
    "metadata": {},
    "source": [
     "Taking 6426 draws for the tract 0 (a draw for each person), on each draw there's a 25% chance that the chosen person is black "
@@ -394,7 +377,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "947a896b-2679-41ed-90d0-33a38fdcb113",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.426522Z",
@@ -412,7 +394,6 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "952a1672-89e4-41be-b7e2-77767969acd3",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.455870Z",
@@ -563,7 +544,6 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "dbe5f777-f7fe-480e-940d-8d6884d82cbd",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:48.473808Z",
@@ -608,7 +588,6 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "0d9d60c7-6dfc-4c17-8039-90c0c864ef57",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.620754Z",
@@ -637,7 +616,6 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "6c82a423-da59-4957-afb5-6d6b0c7559c5",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.626861Z",
@@ -666,7 +644,6 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "adceaf5c-a493-4808-875b-51fa37244186",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.632782Z",
@@ -695,7 +672,6 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "b3c6c859-c3b2-4933-9ae5-fc49bc757593",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.656565Z",
@@ -724,7 +700,6 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "eb467b32-6f73-4052-9a97-d990f88ba094",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.662233Z",
@@ -753,7 +728,6 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "c8f102ca-3118-44c5-afb0-f84144e238f5",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.667233Z",
@@ -782,7 +756,6 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "14ce9ca1-c46a-46ab-8065-f2eb86b659a7",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.672623Z",
@@ -810,7 +783,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41ad04bb-df24-45ea-9117-8b22f0ce9bb7",
    "metadata": {},
    "source": [
     "We haven't changed total population in each unit or the region, but we have changed the number of `group X` in the region marginally"
@@ -818,7 +790,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6f9ea51-e339-4c3d-9c74-f57134542f71",
    "metadata": {},
    "source": [
     "## Systematic Randomization"
@@ -826,7 +797,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e62120a-7f01-428e-ae76-2b5653974d19",
    "metadata": {},
    "source": [
     "The systematic approach takes draws from the regional population of each group, with the probability of choosing geographic unit X equal to the share of the region's population that currently lives there (people drawing from a distribution of locations)"
@@ -835,7 +805,6 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "6b10a195-ff3b-4851-ab24-2380073ccda7",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.678993Z",
@@ -864,7 +833,6 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "5d705979-b2c3-419f-aedd-6943dc75782c",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.706990Z",
@@ -893,7 +861,6 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "54f68f65-d6cd-48ac-84ae-cfdbd1bd9c20",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.717101Z",
@@ -926,7 +893,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "552da106-64c8-41f6-a389-5fae954710a0",
    "metadata": {},
    "source": [
     "Out of 1426445 nonhispanic black people in the DC region there's a 0.1133% chance that they will live in tract 0"
@@ -935,7 +901,6 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "a9dd65d1-b4a2-4267-a12f-e4e151603551",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.725044Z",
@@ -953,7 +918,6 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "7b6d29e4-eb5c-4c39-b1c6-6f2939c5555c",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.756962Z",
@@ -1128,7 +1092,6 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "97eeca75-beae-4ebc-9f82-49489bcb3260",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.778871Z",
@@ -1157,7 +1120,6 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "5fb512e0-f15e-4a63-92c0-4bf2a8f45626",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.825526Z",
@@ -1186,7 +1148,6 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "64e1aeb8-08f6-45b0-adfb-ea256c65cab4",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.833029Z",
@@ -1215,7 +1176,6 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "dcc0d5b5-c479-4902-8533-7c5031d212e8",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.858369Z",
@@ -1243,7 +1203,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6bf3ed7-10e2-47ca-927f-962572940e08",
    "metadata": {},
    "source": [
     "We haven't changed the total number of people in each group, but we have changed the total number of people in each unit"
@@ -1251,7 +1210,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59839d01-aad2-45b9-a93a-c042f3104e1e",
    "metadata": {},
    "source": [
     "### Individual-level Permutation"
@@ -1259,7 +1217,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "083718ae-d28e-44d2-a8cd-0ed2c03526af",
    "metadata": {},
    "source": [
     "Individual-level permutation doesn't take draws from a probability distribution, but instead randomizes which unit each person lives in"
@@ -1268,7 +1225,6 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "7c90897f-e31e-49b9-b3de-a62e70f09216",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:49.904327Z",
@@ -1286,7 +1242,6 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "06108d13-9c94-4140-a77a-f6e0610d0444",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.782725Z",
@@ -1315,7 +1270,6 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "195cdb76-b3f9-4850-8e70-6bcf307eb523",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.808247Z",
@@ -1344,7 +1298,6 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "54fd0754-9cdb-4ea8-b7fe-e42a5410fa3b",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.815318Z",
@@ -1373,7 +1326,6 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "cc154854-53c0-44d4-aa80-23ce62bea3ec",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.822845Z",
@@ -1401,7 +1353,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58b27471-0553-4409-b813-433e948b068e",
    "metadata": {},
    "source": [
     "We haven't changed the total number of people in any group, or changed the total population in any unit, we've only randomized which unit each person lives in"
@@ -1409,7 +1360,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "031fa379-8b67-41f4-a3e0-e252f4d47d10",
    "metadata": {},
    "source": [
     "## Simulating Null Distributions"
@@ -1417,7 +1367,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4152017-6928-4816-8c74-08164254f07e",
    "metadata": {},
    "source": [
     "The `simulate_null` generates a series of simulated segregation statistics (in parallel) using the randomization functions described above. Following, those simulated values can serve as a reference distribution to test the hypothesis of \"no segregation\""
@@ -1426,7 +1375,6 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "d72ec95e-df35-40ae-91d7-a703b2475827",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.827812Z",
@@ -1444,7 +1392,6 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "2d504546-a843-4097-9260-71cb3077c9a9",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.832458Z",
@@ -1462,7 +1409,6 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "8ab50060-c38b-4c3b-85c3-798b14c84759",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.853626Z",
@@ -1480,7 +1426,6 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "95da5242-47f3-4344-9bd2-da791dd09f12",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.858081Z",
@@ -1501,7 +1446,6 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "86440032-fad9-4719-bbc8-a3411b6a2913",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.863229Z",
@@ -1519,7 +1463,6 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "9332b53c-a11c-4579-9e18-f3d071aba17b",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.910596Z",
@@ -1537,7 +1480,6 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "d921dfc2-12b7-478a-8a1c-64d56620aa08",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.922641Z",
@@ -1566,7 +1508,6 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "815850e0-8aa1-470e-982b-e97089269560",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.931843Z",
@@ -1594,7 +1535,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9d6ea69-429f-445c-9ad0-52718f649fcc",
    "metadata": {},
    "source": [
     "### Single Group"
@@ -1603,7 +1543,6 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "23f54f80-f7d8-46d6-a9b3-80b473c39cdd",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:45:55.953972Z",
@@ -1643,7 +1582,6 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "b029c74c-20fe-4976-ba86-48c2230cc496",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:46:13.813735Z",
@@ -1683,7 +1621,6 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "1311af01-1189-428c-ab01-3fd5e0cbde67",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:46:19.958252Z",
@@ -1731,7 +1668,6 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "29f6b520-7683-44cb-b4ef-8d90d17738dc",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:51:52.932293Z",
@@ -1749,7 +1685,6 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "51453964-24f5-4805-8ee9-9142cde4b30d",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:51:52.957608Z",
@@ -1799,7 +1734,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84cd359e-24c0-4395-a7b0-3dac1c7c75c4",
    "metadata": {},
    "source": [
     "### Multi Group"
@@ -1808,7 +1742,6 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "b6d507bb-9b97-4bc4-8c43-c5d012fd6f4c",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:51:53.425848Z",
@@ -1849,7 +1782,6 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "id": "89fb7b0d-3a2d-413a-9714-3b39018fd973",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:52:01.109372Z",
@@ -1890,7 +1822,6 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "id": "6538b1d2-d695-4a5c-bdbf-5225c1ba5580",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:52:05.822675Z",
@@ -1938,7 +1869,6 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "id": "29981e00-f3d1-4e32-b287-3a559b8e9341",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:57:47.513191Z",
@@ -1988,16 +1918,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b0cecd1-ab4b-4524-b517-1058920a16f7",
    "metadata": {},
    "source": [
-    "Despite their different methods, all three approaches simulate similar distributions, but they differ with respect to *how* and in which dimensions the randomization occurs. As with [Boisso et al](http://dx.doi.org/10.1016/0304-4076(94)90082-5), the distribution is not centered on 0. In other cases, such as when minority populations are small or highly unbalanced among multiple groups, its possible that the different randomization methods could diverge to simulate different distributions"
+    "Despite their different methods, all three approaches simulate similar distributions, but they differ with respect to *how* and in which dimensions the randomization occurs. As with [Boisso et al](http://dx.doi.org/10.1016/0304-4076(94\\)90082-5), the distribution is not centered on 0. In other cases, such as when minority populations are small or highly unbalanced among multiple groups, its possible that the different randomization methods could diverge to simulate different distributions"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc52eb08-cb5e-45a4-90aa-ebbb70c139be",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/06_inference.ipynb
+++ b/notebooks/06_inference.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "eed19dd4-2d69-44c2-b7c9-45aa05f76865",
    "metadata": {},
    "source": [
     "# Single Value and Comparative Inference"
@@ -10,7 +9,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fdca5afb-d633-4fec-ad9b-a9f5578eb375",
    "metadata": {},
    "source": [
     "The `segregation` package provides a framework for examining whether segregation index values are statistically significant (whether a single index is far enough away from \"no segregation\" that it could not happen by chance, or whether two indices are different enough from one another). This framework is useful for understanding, for example:\n",
@@ -24,7 +22,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "e5151bda-3144-4463-af19-114bfc81c2e3",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:40:06.558268Z",
@@ -62,7 +59,6 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "7b431f84-c5b6-4c56-894f-408e5285b337",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:40:15.780265Z",
@@ -83,7 +79,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "abba3acc-b5ae-4e22-9aca-f8a572feec6e",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:40:15.785066Z",
@@ -103,7 +98,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "25f847e5-46ee-4418-b180-bbb6a9d28772",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:40:47.924686Z",
@@ -151,7 +145,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20449d87-0388-47fd-9f73-54c3f27c939e",
    "metadata": {},
    "source": [
     "## Single-Value Inference"
@@ -159,7 +152,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f02be8d-9f97-4125-bb37-61c16d9bac8b",
    "metadata": {},
    "source": [
     "In many contexts, researchers are interested in whether some measured level of segregation is statistically different from a random process. That is, is the level of segregation we observe in place X greater than we would expect if there were no segregation at all?"
@@ -167,15 +159,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32310d52-2769-4f18-a3bc-ffa3748ee989",
    "metadata": {},
    "source": [
-    "For single value inference, the segregation package tests whether the observed segregation index differs from the expected value of a segregation index under the null hypothesis of no segregation. As [Boisso et al](http://dx.doi.org/10.1016/0304-4076(94)90082-5) show, the expected value of \"no segregation\" is not necessarily and index value of 0. The `SingleValueTest` class offers computational inference via a variety of methods for simulating observations under different randomization schemes (See notebook 05_simulating_random_population for more information about the randomization methods and how they differ)"
+    "For single value inference, the segregation package tests whether the observed segregation index differs from the expected value of a segregation index under the null hypothesis of no segregation. As [Boisso et al](http://dx.doi.org/10.1016/0304-4076(94\\)90082-5) show, the expected value of \"no segregation\" is not necessarily and index value of 0. The `SingleValueTest` class offers computational inference via a variety of methods for simulating observations under different randomization schemes (See notebook 05_simulating_random_population for more information about the randomization methods and how they differ)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f3a604ea-b3f3-4ebb-844f-02f09ab46c13",
    "metadata": {},
    "source": [
     "### Evenness"
@@ -184,7 +174,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4a673113-eb77-4c1b-8870-6f1d73c0949a",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:40:48.726242Z",
@@ -214,7 +203,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87a96e24-f5d9-4b52-9acf-b27010fbb78e",
    "metadata": {},
    "source": [
     "The dissimilarity statistic for riverside 2010 is 0.370"
@@ -222,7 +210,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "760d03f7-c13c-4fb1-90f9-e0131a098886",
    "metadata": {},
    "source": [
     "The dissimilarity index is a [measure of evenness](https://www.jstor.org/stable/2579183?seq=1#metadata_info_tab_contents), so it is reasonable to use the `evenness` null approach in the `SingleValueTest` class. For more information on the different randomization procedures used in the single value test, have a look at the 05_simulating_random_population notebook"
@@ -231,7 +218,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "8ca85349-b048-4776-811b-84d5835103d6",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:40:48.758886Z",
@@ -272,7 +258,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "23c22142-1401-4d73-a55c-5f22cbcb39a4",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:03.283155Z",
@@ -300,7 +285,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0b78e7b-c2fd-469f-86ea-986bd59668f1",
    "metadata": {},
    "source": [
     "The p-value for the test is essentially 0. The `plot` method of the class will show the simulated null distribution in blue as well as the observed value for the segregation statistic in red"
@@ -309,7 +293,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "a945f558-0f95-4f27-bdca-e1b2a149e173",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:03.309882Z",
@@ -354,7 +337,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "859954f4-ba4b-4725-8e23-449b7c2e5d75",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:03.772059Z",
@@ -382,7 +364,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7191875-8693-41ce-989b-c358628631b6",
    "metadata": {},
    "source": [
     "The `est_sim` attribute on the SingleValueTest class contains the segregation index values calculated for the synthetic datasets. Here we can see the estimated Dissimilarity index under the assumption of perfect evenness in Riverside is 0.011"
@@ -390,7 +371,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e6d908e-b194-47b1-87b9-33714d03698b",
    "metadata": {},
    "source": [
     "Here the plot shows that if Riverside's population were perfectly even across geographic units, the unequal levels in population groups would still result in a small level of Dissimilarity segregation (just barely above 0). But the distribution is nonetheless tightly distributed around that barely-zero level, whereas observed Dissimilarity in Riverside is 0.37 so we reject the null of \"no segregation\" in favor of the hypothesis that the Hispanic/Latino population in Riverside is significantly segregated."
@@ -398,7 +378,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01013cd8-84bf-4662-8f1d-a68879728342",
    "metadata": {},
    "source": [
     "### Bootstrap"
@@ -406,7 +385,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "428484fe-cf90-48ce-9c06-606a0cc0e110",
    "metadata": {},
    "source": [
     "As an alternative to simulating a null distribution, another resonable test for the Dissimilarity index is a bootstrap approach, used to simulate the distribution of the Dissimilarity index itself, then a given value for \"no segregation\" can be tested against this reference distribution. In practical terms, that means the bootstrapped index value can be tested against 0, or against the value given by a null distribution such as evenness above"
@@ -415,7 +393,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "23a5b140-014a-46a8-bdb4-f3d61ccf1dc1",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:03.780389Z",
@@ -458,7 +435,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "00423e4d-6b37-483d-be5c-1a432ab67ef9",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:07.354747Z",
@@ -502,7 +478,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59920a48-2e94-4eb1-8d99-f5b79098782d",
    "metadata": {},
    "source": [
     "Plotting a `SingleValueTest` with the bootstrap method now shows the bootstrapped distribution of the segregation index versus the point estimate of no segregation (rather than the point estimate of the segregation index versus the simulated null distribution in the evenness approach above)"
@@ -511,7 +486,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "b9f32798-b1bb-4ee9-9e16-cae3fc5550e8",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:07.811144Z",
@@ -553,7 +527,6 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "e3e2b1c9-4025-439f-b6a6-4cb0e7651472",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:10.806292Z",
@@ -597,7 +570,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "837a6b78-badf-4cad-9892-d0b2359a4764",
    "metadata": {},
    "source": [
     "Whether we test against 0 or the simulated value from evenness, our inference is the same: we reject the null; Riverside is clearly segregated according to this test"
@@ -605,7 +577,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd442908-db09-4dda-b4e8-4e7158197102",
    "metadata": {},
    "source": [
     "### Random Geographic Permutation"
@@ -613,7 +584,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5c70924-e9cc-4de6-8c19-62049f2e0d07",
    "metadata": {},
    "source": [
     "Alternatively, we might have examined a different segregation index, such as the Relative Concentration index, a spatial measure for which a different test would be appropriate"
@@ -621,7 +591,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2168a578-92e2-4022-a1bd-1f5145044adf",
    "metadata": {},
    "source": [
     "The random geographic permutation test shuffles the values of tracts in space to create a spatially-random distribution. This test leaves the total population in each group of each geographic unit, but randomizes where the unit exists in space"
@@ -630,7 +599,6 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "8ecf3e76-1004-4c2a-8211-fcb456587af0",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:11.233226Z",
@@ -649,7 +617,6 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "6cac7eb7-9754-42d2-ae75-354cd6506d2a",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:11.485325Z",
@@ -668,7 +635,6 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "83379e7f-8c55-44f1-8258-ffafa91050d0",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:11.521993Z",
@@ -697,7 +663,6 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "9f028f6d-c8bc-4c5d-8eb3-c566a102dab2",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:11.529142Z",
@@ -738,7 +703,6 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "a2cdc1cc-6bb5-4f12-bb09-cc636fa3355f",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:16.223855Z",
@@ -767,7 +731,6 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "cab3c7a2-5af7-4f16-afe0-69fd57beb94a",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:16.233166Z",
@@ -811,7 +774,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de91fc4a-b880-407e-94e3-8d6dc67ff98f",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-23T23:58:22.571774Z",
@@ -827,7 +789,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d01c96e-e35b-4722-98f6-e85f85bee7d8",
    "metadata": {},
    "source": [
     "It is also possible to combine the two previous approaches to first generate a simulated population under the assumption of evenness, *then* geographically permute the simulated data"
@@ -836,7 +797,6 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "5584be46-138c-4e1d-94a0-2560568a7d70",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:16.704516Z",
@@ -877,7 +837,6 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "35147f5d-76de-44e2-bb86-2a6de501226f",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:22.058268Z",
@@ -921,7 +880,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c17829c5-8d68-40d3-a8d8-80f4ed4db2c0",
    "metadata": {},
    "source": [
     "Here the inference becomes even stronger that we reject the null"
@@ -929,7 +887,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff56a4ec-b704-4765-9e0e-59f7f4d4bee9",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-23T22:54:56.705909Z",
@@ -945,7 +902,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66d7918d-f5fd-4377-85a4-6fbb5277df41",
    "metadata": {},
    "source": [
     "Comparative inference is particularly useful in studying residential segregation because it facilitates both temporal and spatial comparisons, allowing researchers to ask whether one place is more segregated than another, or whether a given place has become more/less segregated over time."
@@ -953,7 +909,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bee8bf28-97d4-44b3-b6f9-2b0f9dfd2fef",
    "metadata": {},
    "source": [
     "As with single-value inference, the `TwoValueTest` class offers several techniques for conducting the analysis"
@@ -962,7 +917,6 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "4364f038-383c-4659-8d1d-fb83365de394",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:22.471573Z",
@@ -982,7 +936,6 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "515f34a1-d9cd-41fe-b8c5-b21edaad130d",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:41:56.062366Z",
@@ -1002,7 +955,6 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "3b87b2fc-41a8-4dbf-a3a4-16731e40c4c9",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:27.126572Z",
@@ -1048,7 +1000,6 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "84daced6-c4b2-49b4-9040-6fd5003fe5b9",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:38.273120Z",
@@ -1078,7 +1029,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c005ae03-1e1e-46ee-9469-914b60096275",
    "metadata": {},
    "source": [
     "The dissimilarity statistic for LA 2010 is 0.518"
@@ -1087,7 +1037,6 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "aafd1ac1-9952-440e-86cf-daa3773d8ea2",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:38.303993Z",
@@ -1117,7 +1066,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2d979ba-6a46-45eb-bdd6-d0f667ab08b4",
    "metadata": {},
    "source": [
     "The dissimilarity statistic for LA 1990 is 0.507  \n",
@@ -1127,7 +1075,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bc6540d-1aab-4e6d-ac23-0e3c7625dab8",
    "metadata": {},
    "source": [
     "Again, there are several methods available for testing differences between segregation values. Random labelling, based on [Rey and Guitierrez](http://www.tandfonline.com/doi/abs/10.1080/17421772.2010.493955) creates a set of synthetic observations by shuffling geographic units between the two cities, calculating segregation statistics on these synthetic datasets, then taking the difference between the statistics. This process results in a distribution of differences (under the null that there is no difference between the cities), and we test the observed difference against this distribution"
@@ -1135,7 +1082,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8001c3e-dfa7-4c5c-a5a4-7ab9e2a1be32",
    "metadata": {},
    "source": [
     "### Random Labeling"
@@ -1144,7 +1090,6 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "42abc481-b90e-45ac-964d-bd53cb82273a",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:38.322738Z",
@@ -1184,7 +1129,6 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "0a2b5953-e0ba-4744-a326-6999855b881a",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:39.081618Z",
@@ -1212,7 +1156,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a7abd3e-b490-4408-9761-fc1016130c77",
    "metadata": {},
    "source": [
     "There's a 21.2% chance of obtaining these results at random, so we fail to reject the null hypothesis that there is no difference in segregation between the two time periods"
@@ -1221,7 +1164,6 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "277ff1d2-e15b-4e59-b6e0-bd87a88eb152",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:39.106776Z",
@@ -1264,7 +1206,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e0af979-d1f7-48cc-9cf3-bc1760cfa3ae",
    "metadata": {},
    "source": [
     "Plotting the class shows the distribution of simulated differences in blue as well as the estimated difference in red. Here it is clear that the observed difference falls well within the distribution"
@@ -1272,7 +1213,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f5b0bdb-1f77-4e7b-91b5-9f20f6caf888",
    "metadata": {},
    "source": [
     "#### LA vs Riverside"
@@ -1281,7 +1221,6 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "2762f974-7c01-4913-a02c-7dc00081a8a7",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:39.709452Z",
@@ -1321,7 +1260,6 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "400e4eda-96d0-49c6-9893-f97ee1c45502",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:40.371714Z",
@@ -1364,7 +1302,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a57ee39-0ec4-4756-8d45-fdae959ce48a",
    "metadata": {},
    "source": [
     "The results show that LA is significantly more segregated than Riverside, but LA is not significantly more segregated in 2010 than it was in 1990"
@@ -1372,7 +1309,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a7b95e4-3159-466b-932f-24365fce132e",
    "metadata": {},
    "source": [
     "### Bootstrap"
@@ -1380,7 +1316,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85cbe1c4-4fb4-4ef8-9c92-c84c36beb62a",
    "metadata": {},
    "source": [
     "The bootstrap test based on [Davidson 2009](http://dx.doi.org/10.1016/j.jeconom.2008.11.004) uses the bootstrap resampling technique to estimate a distribution of the segregation index for each city, which provides an estimate of each index's variance. Following, we perform a means test to see whether the mean of each distribution is significantly different from one another"
@@ -1388,7 +1323,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c69335b-54c4-4e99-9070-4b4094c44991",
    "metadata": {},
    "source": [
     "#### LA over time"
@@ -1397,7 +1331,6 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "4659f524-4404-4000-81ef-4612cb7c51d5",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:40.881590Z",
@@ -1458,7 +1391,6 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "da739d67-681c-4aa9-8cf7-6ce587143aaf",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:49.817169Z",
@@ -1487,7 +1419,6 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "4b39a27b-202f-4f3c-a8d0-4f74e58e3b18",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:49.826243Z",
@@ -1530,7 +1461,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44d7d544-2792-46ad-96be-c0750a46115d",
    "metadata": {},
    "source": [
     "Plotting a TwoValueTest class with the bootstrap method shows the bootstrapped distributions for both segregation indices. Here we can clearly see that the distributions overlap substantially"
@@ -1538,7 +1468,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e2eb598-7c44-4743-baee-4f66916d698e",
    "metadata": {},
    "source": [
     "#### LA vs Riverside"
@@ -1547,7 +1476,6 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "879a0ba7-4a55-44c2-b69c-193e3f44b19f",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:50.311679Z",
@@ -1608,7 +1536,6 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "a4275d86-f9ce-439b-8a45-c41de5869309",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:59.016907Z",
@@ -1636,7 +1563,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "334c685e-5726-46ad-84c0-73be47ce83d2",
    "metadata": {},
    "source": [
     "The test is highly significant"
@@ -1645,7 +1571,6 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "b2d19b9a-f202-485f-81ab-12a5bebe9208",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-07-24T00:42:59.026518Z",
@@ -1688,7 +1613,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e093b015-a6eb-4724-af24-5357222ed17d",
    "metadata": {},
    "source": [
     "Plotting the class shows the wide berth between distributions, explaining why the p-value is so low."
@@ -1696,7 +1620,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37a122b6-50f3-45a9-a437-a68a1cbd4956",
    "metadata": {},
    "source": [
     "Again, the results show a significant difference between Riverside and LA, but not LA over time"
@@ -1704,7 +1627,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c7fb7b2-a07e-4066-be4e-57463425e926",
    "metadata": {},
    "source": [
     "**Note**: The bootstrap test is only appropriate for aspatial segregation indices, first because simple bootstrap techniques do not account for spatial autocorrelation, and second because bootstrapping spatial units results in synthetic regions that have duplicate units (and thus the data are not planar enforced, so a spatial index cannot be computed)"
@@ -1712,7 +1634,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b804617-4373-438f-80d2-546dfa3b206a",
    "metadata": {},
    "source": [
     "For comparative inference, there are also additional randomization approaches based on counterfactual population generation described in the 07_decomposition notebook"
@@ -1721,7 +1642,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af7767a3-dcda-4aea-8c75-e1c4eb72f68c",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Not sure why the ids are changed in the notebooks? I did not execute any of them, just added the [escape on the backwards paren](https://github.com/knaaptime/segregation/compare/popgen...ljwolf:popgen#diff-1c805f83ea87e928a32f97ddb77b4648f59da784bae25054eb77096a21067049R1923) in notebooks 05 and 06